### PR TITLE
Update package.json to use latest ask-sdk-jsx-for-apl beta version

### DIFF
--- a/lambda/package.json
+++ b/lambda/package.json
@@ -10,7 +10,7 @@
     "react": "~16.8.3",
     "react-dom": "~16.8.3",
     "lodash": "^4.17.15",
-    "ask-sdk-jsx-for-apl": "1.0.0-beta"
+    "ask-sdk-jsx-for-apl": "^1.0.0-beta"
   },
   "devDependencies": {
     "@babel/cli": "^7.8.4",


### PR DESCRIPTION
## Description of changes:
- skill-sample-jsx-for-apl-fruit-nutrition-facts always runs with the latest JSX for APL beta version.
